### PR TITLE
Add loongarch64 support

### DIFF
--- a/src/main/java/org/redline_rpm/header/Architecture.java
+++ b/src/main/java/org/redline_rpm/header/Architecture.java
@@ -14,6 +14,7 @@ public enum Architecture {
 	IA64,
 	SPARC64,
 	MIPSEL,
+	LOONGARCH64,
 	ARM,
 	MK68KMINT,
 	S390,


### PR DESCRIPTION
LoongArch is a risc architecture, like RISCV. This PR is used to support LoongArch.